### PR TITLE
Using argv[0] to run "fbi / fbpdf" on fbdev or kms/drm interfaces

### DIFF
--- a/fbi.c
+++ b/fbi.c
@@ -1220,7 +1220,7 @@ int main(int argc, char *argv[])
     int              i, arg, key;
     bool             framebuffer = false;
     bool             use_libinput;
-    char             *info, *desc, *device, *output, *mode;
+    char             *basename, *info, *desc, *device, *output, *mode;
     char             linebuffer[128];
     struct flist     *fprev = NULL;
     struct flist     *fnext = NULL;
@@ -1302,21 +1302,17 @@ int main(int argc, char *argv[])
     device = cfg_get_str(O_DEVICE);
     output = cfg_get_str(O_OUTPUT);
     mode = cfg_get_str(O_VIDEO_MODE);
-    if (device) {
-        /* device specified */
-        if (strncmp(device, "/dev/d", 6) == 0) {
-            gfx = drm_init(device, output, mode, false);
-        } else {
-            framebuffer = true;
-            gfx = fb_init(device, mode);
-        }
+    basename = strrchr(argv[0], '/');
+    if (basename)
+        basename++;
+    else
+        basename = argv[0];
+
+    if (strcmp(basename, "fbi") == 0) {
+        framebuffer = true;
+        gfx = fb_init(device, mode);
     } else {
-        /* try drm first, failing that fb */
-        gfx = drm_init(NULL, output, mode, false);
-        if (!gfx) {
-            framebuffer = true;
-            gfx = fb_init(NULL, mode);
-        }
+        gfx = drm_init(device, output, mode, false);
     }
     if (!gfx) {
         fprintf(stderr, "graphics init failed\n");

--- a/fbpdf.c
+++ b/fbpdf.c
@@ -241,6 +241,7 @@ int main(int argc, char *argv[])
     bool framebuffer = false;
     bool use_libinput;
     bool quit, newpage, pageflip;
+    char *basename;
     char cwd[1024];
     char uri[1048];
     char key[32];
@@ -298,22 +299,17 @@ int main(int argc, char *argv[])
     fitwidth = GET_FIT_WIDTH();
     pageflip = GET_PAGEFLIP();
     use_libinput = GET_LIBINPUT();
+    basename = strrchr(argv[0], '/');
+    if (basename)
+        basename++;
+    else
+        basename = argv[0];
 
-    if (device) {
-        /* device specified */
-        if (strncmp(device, "/dev/d", 6) == 0) {
-            gfx = drm_init(device, output, mode, pageflip);
-        } else {
-            framebuffer = true;
-            gfx = fb_init(device, mode);
-        }
+    if (strcmp(basename, "fbpdf") == 0) {
+        framebuffer = true;
+        gfx = fb_init(device, mode);
     } else {
-        /* try drm first, failing that fb */
-        gfx = drm_init(NULL, output, mode, pageflip);
-        if (!gfx) {
-            framebuffer = true;
-            gfx = fb_init(NULL, mode);
-        }
+        gfx = drm_init(device, output, mode, pageflip);
     }
     if (!gfx) {
         fprintf(stderr, "graphics init failed\n");

--- a/meson.build
+++ b/meson.build
@@ -106,6 +106,12 @@ executable('fbi',
            install             : true)
 install_man('man/fbi.1')
 
+custom_target('kmsi',
+              build_by_default : true,
+              output  : ['kmsi'],
+              command : [ 'ln', '-sf', 'fbi', '@OUTPUT@'])
+meson.add_install_script('sh', '-c', 'ln -sf fbi $DESTDIR@0@/@1@/kmsi'.format(get_option('prefix'), get_option('bindir')))
+
 # build exiftran
 exiftr_srcs  = [ 'exiftran.c', 'genthumbnail.c', 'jpegtools.c',
                  'filter.c', 'op.c', 'readers.c', 'rd/read-jpeg.c',
@@ -136,6 +142,12 @@ executable('fbpdf',
            sources             : fbpdf_srcs,
            dependencies        : fbpdf_deps,
            install             : true)
+
+custom_target('kmspdf',
+              build_by_default : true,
+              output  : ['kmspdf'],
+              command : [ 'ln', '-sf', 'fbpdf', '@OUTPUT@'])
+meson.add_install_script('sh', '-c', 'ln -sf fbpdf $DESTDIR@0@/@1@/kmspdf'.format(get_option('prefix'), get_option('bindir')))
 
 # build fbcon
 fbcon_srcs   = [ 'fbcon.c', 'drmtools.c', 'fbtools.c', 'gfx.c',


### PR DESCRIPTION
Commands starting with "fb" were commonly used for programs running on fbdev.
To avoid any ambiguity, this change allows running "fbi / fbpdf" on the fbdev or kms/drm interfaces depending on the name of the command: the kmsi and kmspdf symbolic links are created for this purpose.

Nicolas Caramelli