### PR TITLE
fbida: Include missing <sys/types.h>

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -1,6 +1,6 @@
 #include <stdbool.h>
 #include <inttypes.h>
-#include <sys/stat.h>  /* dev_t */
+#include <sys/types.h>  /* dev_t */
 
 #include <pixman.h>
 #include <cairo.h>


### PR DESCRIPTION
Fixes build on musl
../git/gfx.h:43:5: error: unknown type name 'dev_t'; did you mean 'div_t'?
    dev_t devnum;
    ^~~~~
    div_t
TOPDIR/build/tmp/work/cortexa57-yoe-linux-musl/fbida/2.14+gitAUTOINC+eb769e3d7f-r0/recipe-sysroot/usr/include/stdlib.h:64:35: note: 'div_t' declared here typedef struct { int quot, rem; } div_t;
                                  ^
1 error generated