### PR TITLE
fbdev: pick 32bpp pixman format by red channel offset

### DIFF
--- a/fbtools.c
+++ b/fbtools.c
@@ -297,7 +297,10 @@ gfxstate* fb_init(const char *device, char *mode)
         fb_linear_palette(5,6,5);
 	break;
     case 32:
-        fmt = gfx_fmt_find_pixman(PIXMAN_x8r8g8b8);
+        if (fb_var.red.offset == 0)
+            fmt = gfx_fmt_find_pixman(PIXMAN_x8b8g8r8);
+        else
+            fmt = gfx_fmt_find_pixman(PIXMAN_x8r8g8b8);
         fb_linear_palette(8,8,8);
 	break;
     }

--- a/gfx.c
+++ b/gfx.c
@@ -46,6 +46,16 @@ gfxfmt fmt_list[] = {
         .depth    = 30,
         .bpp      = 32,
     },
+    {
+        /* fbdev with red at offset 0, e.g. simple-framebuffer
+         * format = "a8b8g8r8" / "x8b8g8r8" on some arm devices.
+         * cairo has no ABGR variant; the fbdev path only needs pixman. */
+        .fourcc   = DRM_FORMAT_XBGR8888,
+        .cairo    = CAIRO_FORMAT_INVALID,
+        .pixman   = PIXMAN_x8b8g8r8,
+        .depth    = 24,
+        .bpp      = 32,
+    },
 #endif
 };
 


### PR DESCRIPTION
fbi assumes every 32 bpp framebuffer is x8r8g8b8 (fbtools.c, fb_init).
On devices where the framebuffer is a8b8g8r8/x8b8g8r8 (e.g. a
simple-framebuffer with `format = "a8b8g8r8"` in the device tree), red
and blue come out swapped.

This picks the pixman format from `fb_var.red.offset` as reported by
FBIOGET_VSCREENINFO (offset 0 -> x8b8g8r8, otherwise x8r8g8b8 as
before), and adds the x8b8g8r8 entry to fmt_list. cairo has no ABGR
variant, so that field is CAIRO_FORMAT_INVALID; the fbdev path only
uses pixman. No behavior change for existing x8r8g8b8 framebuffers.

Tested on hardware (Google Nexus 9, tegra132, mainline 6.19,
postmarketOS, simple-framebuffer `a8b8g8r8`): displayed a pure-red
image with fbi and read back /dev/fb0:

    before:  00 00 fe 00   (red written to byte 2 -> shows blue)
    after:   fe 00 00 00   (red at byte 0, matches fbdev offsets)

Found while building a photo frame on this device; happy to test
follow-ups on the hardware.
